### PR TITLE
Resolve files with underscore prefixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-node_modules
+/node_modules

--- a/index.js
+++ b/index.js
@@ -1,12 +1,27 @@
-var path = require('path');
-var resolve = require('resolve');
+'use strict';
+
+const path = require('path');
+const resolve = require('resolve');
+
+function resolveWithUnderscore(id, options) {
+    let file;
+    try {
+        file = resolve.sync(id, options);
+    } catch (e) {
+        const newFile = path.dirname(id) + path.sep + `_${path.basename(id)}`;
+        file = resolve.sync(newFile, options);
+    }
+
+    return file;
+}
+
 module.exports = function (url, prev) {
     if (url.indexOf('~') !== 0) {
         return {file: url};
     }
     url = url.substr(1);
     return {
-        file: resolve.sync(url, {
+        file: resolveWithUnderscore(url, {
             extensions: ['.css', '.scss'],
             basedir: path.dirname(prev)
         })

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "author": "1stdibs.com, Inc.",
   "scripts": {
     "test": "mocha",
-    "gitlint": "dibslint --git --warnings",
-    "lint": "dibslint --root=."
+    "gitlint": "dibslint --git --es6 --warnings",
+    "lint": "dibslint --es6 --root=."
   },
   "main": "index.js",
   "pre-commit": {

--- a/test/specs.js
+++ b/test/specs.js
@@ -1,8 +1,7 @@
 "use strict";
-var scssNodeResolve = require('../index');
-var assert = require('assert');
-var resolve = require('resolve');
-var path = require('path');
+const scssNodeResolve = require('../index');
+const assert = require('assert');
+const path = require('path');
 describe("scss-node-resolve", function () {
     it("should no worry about paths that don't begin with a tilde", function () {
         assert.deepEqual(scssNodeResolve('foo/bar/foo'), {
@@ -30,6 +29,18 @@ describe("scss-node-resolve", function () {
             path.join(
                 __dirname,
                 '../node_modules/empty-module/index.js'
+            )
+        );
+    });
+    it('should resolve like node resolve when path begins with a tilde and the filename starts with an underscore', function () {
+        assert.equal(
+            scssNodeResolve(
+                '~scsstest/foo',
+                __dirname + '/.'
+            ).file,
+            path.join(
+                __dirname,
+                './node_modules/scsstest/_foo.scss'
             )
         );
     });


### PR DESCRIPTION
Unfortunately 1stdibs.com is using both ~ and _ to resolve sass files
